### PR TITLE
Allow `box` allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,61 @@
 [root]
 name = "miri"
 version = "0.1.0"
+dependencies = [
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ license = "ISC"
 [[bin]]
 name = "miri"
 doc = false
+
+[dependencies]
+log = "*"
+env_logger = "*"

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -24,6 +24,8 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
 }
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
+    let mut args: Vec<String> = std::env::args().collect();
+    args.push(String::from("--sysroot"));
+    args.push(format!("{}/.multirust/toolchains/nightly", std::env::var("HOME").unwrap()));
     rustc_driver::run_compiler(&args, &mut MiriCompilerCalls);
 }

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -3,6 +3,7 @@
 extern crate miri;
 extern crate rustc;
 extern crate rustc_driver;
+extern crate env_logger;
 
 use miri::interpreter;
 use rustc::session::Session;
@@ -24,6 +25,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
 }
 
 fn main() {
+    env_logger::init().unwrap();
     let mut args: Vec<String> = std::env::args().collect();
     args.push(String::from("--sysroot"));
     args.push(format!("{}/.multirust/toolchains/nightly", std::env::var("HOME").unwrap()));

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -474,6 +474,7 @@ pub fn interpret_start_points<'tcx>(tcx: &ty::ctxt<'tcx>, mir_map: &MirMap<'tcx>
                 if !check_expected(&val_str, attr) {
                     println!("=> {}\n", val_str);
                 }
+                break;
             }
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -79,7 +79,7 @@ impl Pointer {
 #[derive(Debug)]
 struct Frame {
     /// A pointer to a stack cell to write the return value of the current call, if it's not a
-    /// divering call.
+    /// diverging call.
     return_ptr: Option<Pointer>,
 
     offset: usize,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -430,6 +430,9 @@ impl<'a, 'tcx> Interpreter<'a, 'tcx> {
                 panic!("tried to offset a non-aggregate");
             }
         }
+        if let Value::Uninit = *val {
+            panic!("reading uninitialized value at {:?}", p);
+        }
         val.clone()
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -8,8 +8,6 @@ use syntax::attr::AttrMetaMethods;
 use std::iter;
 use std::collections::HashMap;
 
-const TRACE_EXECUTION: bool = false;
-
 #[derive(Clone, Debug, PartialEq)]
 enum Value {
     Uninit,
@@ -163,15 +161,16 @@ impl<'a, 'tcx> Interpreter<'a, 'tcx> {
     }
 
     fn call(&mut self, mir: &Mir, args: &[Value], return_ptr: Option<Pointer>) {
+        debug!("call");
         self.push_stack_frame(mir, args, return_ptr);
         let mut block = mir::START_BLOCK;
 
         loop {
-            if TRACE_EXECUTION { println!("Entering block: {:?}", block); }
+            debug!("Entering block: {:?}", block);
             let block_data = mir.basic_block_data(block);
 
             for stmt in &block_data.statements {
-                if TRACE_EXECUTION { println!("{:?}", stmt); }
+                debug!("{:?}", stmt);
 
                 match stmt.kind {
                     mir::StatementKind::Assign(ref lvalue, ref rvalue) => {
@@ -186,7 +185,7 @@ impl<'a, 'tcx> Interpreter<'a, 'tcx> {
                 }
             }
 
-            if TRACE_EXECUTION { println!("{:?}", block_data.terminator()); }
+            debug!("{:?}", block_data.terminator());
 
             match *block_data.terminator() {
                 mir::Terminator::Return => break,
@@ -340,6 +339,7 @@ impl<'a, 'tcx> Interpreter<'a, 'tcx> {
     }
 
     fn eval_rvalue(&mut self, rvalue: &mir::Rvalue) -> Value {
+        debug!("eval_rvalue: {:?}", rvalue);
         match *rvalue {
             mir::Rvalue::Use(ref operand) => self.eval_operand(operand),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@
 extern crate rustc;
 extern crate rustc_mir;
 extern crate syntax;
+#[macro_use] extern crate log;
 
 pub mod interpreter;

--- a/test/basic.rs
+++ b/test/basic.rs
@@ -1,4 +1,4 @@
-#![feature(custom_attribute)]
+#![feature(custom_attribute, box_syntax)]
 #![allow(dead_code, unused_attributes)]
 
 #[miri_run(expected = "Int(1)")]
@@ -171,6 +171,13 @@ fn match_opt_some() -> i32 {
 #[miri_run(expected = "Int(1)")]
 fn cross_crate_fn_call() -> i32 {
     if 1i32.is_positive() { 1 } else { 0 }
+}
+
+/// Test boxing and unboxing a value
+#[miri_run(expected = "Int(42)")]
+fn boxing() -> i32 {
+    let x = box 42;
+    *x
 }
 
 fn main() {}


### PR DESCRIPTION
This allows allocations done with the box-syntax. There's some groundwork that made sure that aggregates aren't split up anymore (which made pointers more than just an offset into the stack, pointers now also contain a list of offsets that need to be traversed during dereferencing).

I also split the stack into one stack per function, which makes the code a little simpler imo. A stack pointer is now two addresses. One for the stack frame, and one for the stack element.